### PR TITLE
Updated Response generator to include current date

### DIFF
--- a/src/OcspResponder.Core/OcspResponder.cs
+++ b/src/OcspResponder.Core/OcspResponder.cs
@@ -97,7 +97,7 @@ namespace OcspResponder.Core
                 signatureAlgorithm,
                 await OcspResponderRepository.GetResponderPrivateKey(issuerCertificate),
                 await OcspResponderRepository.GetChain(issuerCertificate),
-                nextUpdate.UtcDateTime);
+                DateTimeOffset.UtcNow.UtcDateTime);
 
             var ocspResponse = OcspResponseGenerator.Generate(OcspRespStatus.Successful, basicOcspResponse);
             return ocspResponse;


### PR DESCRIPTION
There is an issue in which the `IssuedAt` parameter is set to the next update date, as opposed to the current date.